### PR TITLE
copy parameters to a buffer

### DIFF
--- a/examples/arg_handle/axpy_op.cpp
+++ b/examples/arg_handle/axpy_op.cpp
@@ -98,6 +98,75 @@ at::Tensor axpy3(const at::Tensor &x,
   return out;
 }
 
+at::Tensor axpy3_manual(const at::Tensor &x,
+                        const std::optional<at::Tensor> &y,
+                        const std::optional<c10::Scalar> &alpha) {
+  at::Tensor out = [&]() {
+    if (!y.has_value()) {
+      return at::empty_like(x);
+    } else {
+      auto res = torch::broadcast_tensors({x, y.value()});
+      res[0] = res[0].contiguous();
+      res[1] = res[1].contiguous();
+      const at::Tensor &xx = res[0];
+      const at::Tensor &yy = res[1];
+
+      // TODO: consider weak-type of alpha here
+      at::ScalarType out_dtype = at::promote_types(x.scalar_type(), y.value().scalar_type());
+      return at::empty(xx.sizes(), at::TensorOptions().dtype(out_dtype).device(x.device()));
+    }
+  }();
+  const TritonJITFunction &f = TritonJITFunction::get_instance(std::string("axpy.py"), "axpy3_kernel");
+
+  ParameterBuffer buffer;
+  const int num_args = 3;
+  buffer.reserve(num_args);
+  c10::SmallVector<std::string> signature;
+  signature.reserve(num_args);
+  ArgHandle handler = {f.get_static_sig(), buffer, signature, 0};
+
+  int64_t tile_size = 1024;
+  const int num_warps = 8;
+  const int num_stages = 1;
+  int64_t n = out.numel();
+
+  // add each arg manually
+  handler.handle_arg(x);
+  handler.handle_arg(y);
+  handler.handle_arg(out);
+  handler.handle_arg(alpha);
+  handler.handle_arg(n);
+  handler.handle_arg(tile_size);
+
+  void *global_scratch = nullptr;
+  // data_pointers.push_back(global_scratch);
+  // kernel_args.push_back(&(data_pointers.back()));
+  buffer.push_arg(global_scratch);
+  std::string full_signature;
+  for (int i = 0; i < signature.size(); i++) {
+    if (i == 0) {
+      full_signature += signature[i];
+    } else {
+      full_signature += ",";
+      full_signature += signature[i];
+    }
+  }
+
+  const unsigned int num_blocks = (n + tile_size - 1) / tile_size;
+  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
+  c10::DeviceGuard guard(out.device());
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+
+  // TODO: use torch backend-agnostic device APIs
+  ensure_cuda_context();
+  CUdevice device_index;
+  checkCudaErrors(cuCtxGetDevice(&device_index));
+  const TritonKernel &kernel = f.get_kernel(full_signature, num_warps, num_stages, device_index);
+  kernel.launch(num_blocks, 1, 1, num_warps, stream, buffer.get_ptrs());
+  return out;
+}
+
 TORCH_LIBRARY(my_ops, m) {
   m.def("axpy(Tensor self, Tensor other, Scalar alpha) -> Tensor");
   m.def("axpy2(Tensor self, Tensor other, Scalar? alpha) -> Tensor");

--- a/examples/arg_handle/axpy_op.h
+++ b/examples/arg_handle/axpy_op.h
@@ -11,5 +11,7 @@ at::Tensor axpy2(const at::Tensor &x, const at::Tensor &y, const std::optional<c
 at::Tensor axpy3(const at::Tensor &x,
                  const std::optional<at::Tensor> &y,
                  const std::optional<c10::Scalar> &alpha);
-
+at::Tensor axpy3_manual(const at::Tensor &x,
+                        const std::optional<at::Tensor> &y,
+                        const std::optional<c10::Scalar> &alpha);
 }  // namespace my_ops

--- a/examples/arg_handle/test_axpy.cpp
+++ b/examples/arg_handle/test_axpy.cpp
@@ -70,3 +70,23 @@ TEST(arg_handle_test, optional_tensor_nullopt) {
   at::Tensor result2 = alpha * a;
   EXPECT_TRUE(torch::allclose(result1, result2));
 }
+
+TEST(arg_handle_test_manual, optional_tensor_has_value) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  std::optional<at::Tensor> b = at::rand({128 * 1024}, at::kCUDA);
+
+  c10::Scalar alpha(3.14);
+  at::Tensor result1 = my_ops::axpy3_manual(a, b, alpha);
+  at::Tensor result2 = at::add(alpha * a, b.value());
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}
+
+TEST(arg_handle_test_manual, optional_tensor_nullopt) {
+  at::Tensor a = at::rand({128 * 1024}, at::kCUDA);
+  std::optional<at::Tensor> b = std::nullopt;
+
+  c10::Scalar alpha(3.14);
+  at::Tensor result1 = my_ops::axpy3_manual(a, b, alpha);
+  at::Tensor result2 = alpha * a;
+  EXPECT_TRUE(torch::allclose(result1, result2));
+}


### PR DESCRIPTION
Changes how `libtriton_jit` handles arguments.

The ArgHandle gathers all parameters to the kernel by taking the address of each argument and push them onto a `std::vector<void*> kernel_args` in a loop. But to do so, we need to ensure that those parameters of the kernel outlives the kernel launch.

In short, if you wan to launch kernel with argument `a, b, c`, you can do it with the runtime API `kernel<<<grid, block>>>(a, b, c)` or the driver API `cuLaunchKernel(kernel, ..., {&a, &b, &c}, ...)`. In the case of Triton, we use the driver API. So basically, we must ensure that those pointer would not dangle.

Since we are processing arguments in a loop, and some of the parameter to the kernel is not the argument itself, but some other variables computed from the argument. For example, the data pointer, instead of the Tensor is passed to the kernel. 

In the implementation before, we carefully gathers all data pointers to avoid dangling pointers. For the case of other types, for example `optional<Tensor>`, `optional<Scalar>`, `optional<int>`, we carefully take the address of the internal member that is intended to be passed to the kernel. 

But there may be some other cases where the parameter to the kernel is not a member of argument being processing, or it may not be allowed to access that member(maybe a private member). In this case, even if we can get `kernel_arg = extract_feat(arg)`, `kernel_arg` is a temporary variable that lives only in the scope of the iteration.

Thus, we implement a new method to keep them alive. That is, we copy them to a container. But to put variables of different types into a container is not that straight forward in c++. Here we choose a low level implementation. Copy them by bytes.

We initialize a buffer of bytes and set the cursor at position 0. Each time we push an argument into it, we first move the cursor to the next position that fits its alignemnt, then memcpy the variable to the buffer at the position the cursor points to, and finally move the cursor forward by the size of the variable. Finally we get pointers to all the variables stored in the buffer.

<img width="878" height="165" alt="image" src="https://github.com/user-attachments/assets/f33427f1-7c07-4ced-a8fe-8f5e1d0417df" />

